### PR TITLE
[FIX] highlighting errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,5 +65,5 @@ locales:
 
 ### Build settings
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge
 paginate: 5


### PR DESCRIPTION
Msg from github :You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml'